### PR TITLE
Fix gnupg failing to fetch keys over ipv6

### DIFF
--- a/cloudpebble-ycmd-proxy/Dockerfile
+++ b/cloudpebble-ycmd-proxy/Dockerfile
@@ -17,6 +17,12 @@ RUN curl -o /tmp/arm-cs-tools.tar https://cloudpebble-vagrant.s3.amazonaws.com/a
 
 ENV NODE_VERSION=4.4.5 NPM_CONFIG_LOGLEVEL=info
 
+# Disable IPv6 in gnupg - can cause key retrieval to fail
+RUN mkdir ~/.gnupg && \
+  echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf && \
+  chmod 700 ~/.gnupg && \
+  chmod 600 ~/.gnupg/dirmngr.conf
+
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
   && for key in \

--- a/cloudpebble/Dockerfile
+++ b/cloudpebble/Dockerfile
@@ -5,6 +5,12 @@ ENV NPM_CONFIG_LOGLEVEL=info NODE_VERSION=9.11.1 DJANGO_VERSION=1.6
 
 # Node stuff.
 
+# Disable IPv6 in gnupg - can cause key retrieval to fail
+RUN mkdir ~/.gnupg && \
+  echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf && \
+  chmod 700 ~/.gnupg && \
+  chmod 600 ~/.gnupg/dirmngr.conf
+
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
   && for key in \


### PR DESCRIPTION
gnupg seems to prever fetching keys over IPv6 wherever possible. However, Docker containers take some configuration to make IPv6 addressing work, resulting in gnupg failing to fetch keys in a default Docker configuration. This fixes this problem by disabling IPv6 support in gnupg before the keys are fetched.