### PR TITLE
Fix broken apt sources for cloudpebble

### DIFF
--- a/cloudpebble-ycmd-proxy/Dockerfile
+++ b/cloudpebble-ycmd-proxy/Dockerfile
@@ -17,6 +17,12 @@ RUN curl -o /tmp/arm-cs-tools.tar https://cloudpebble-vagrant.s3.amazonaws.com/a
 
 ENV NODE_VERSION=4.4.5 NPM_CONFIG_LOGLEVEL=info
 
+# Disable IPv6 in gnupg - can cause key retrieval to fail
+RUN mkdir ~/.gnupg && \
+  echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf && \
+  chmod 700 ~/.gnupg && \
+  chmod 600 ~/.gnupg/dirmngr.conf
+
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
   && for key in \

--- a/cloudpebble/Dockerfile
+++ b/cloudpebble/Dockerfile
@@ -5,6 +5,12 @@ ENV NPM_CONFIG_LOGLEVEL=info NODE_VERSION=9.11.1 DJANGO_VERSION=1.6
 
 # Node stuff.
 
+# Disable IPv6 in gnupg - can cause key retrieval to fail
+RUN mkdir ~/.gnupg && \
+  echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf && \
+  chmod 700 ~/.gnupg && \
+  chmod 600 ~/.gnupg/dirmngr.conf
+
 # gpg keys listed at https://github.com/nodejs/node
 RUN set -ex \
   && for key in \

--- a/cloudpebble/Dockerfile
+++ b/cloudpebble/Dockerfile
@@ -37,6 +37,9 @@ RUN npm install -g npm jshint
 
 # Django stuff
 
+# Fix broken sources.list (jessie repositories have been archived)
+RUN printf "deb http://archive.debian.org/debian/ jessie main\ndeb-src http://archive.debian.org/debian/ jessie main\ndeb http://security.debian.org jessie/updates main\ndeb-src http://security.debian.org jessie/updates main" > /etc/apt/sources.list
+
 RUN apt-get update && apt-get install -y \
     gettext \
     postgresql-client libpq-dev \


### PR DESCRIPTION
Running an `apt update` in the cloudpebble image currently fails. I believe this is due to Debian Jessie repos being archived, and now living at a different location. This fixes this issue by updating `etc/apt/sources.list` to point to the new Jessie repo locations before running `apt update`.